### PR TITLE
Bump pandoc-types version.

### DIFF
--- a/servant-pandoc.cabal
+++ b/servant-pandoc.cabal
@@ -26,7 +26,7 @@ library
   build-depends:       base >=4.7 && <5
                      , http-media >=0.6 && <0.9
                      , lens >=4.9 && <5
-                     , pandoc-types >=1.12 && <1.21
+                     , pandoc-types >=1.22 && <2
                      , servant-docs >= 0.11.1 && < 0.12
                      , unordered-containers >=0.2 && <0.3
                      , text >=1.2 && <1.3


### PR DESCRIPTION
I tested that this builds with ghc-8.10.7:

```
> cabal build all --enable-tests --enable-benchmarks
Resolving dependencies...
Build profile: -w ghc-8.10.7 -O1
In order, the following will be built (use -v for more details):
 - syb-0.7.2.2 (lib) (requires download & build)
 - pandoc-types-1.22.2.1 (lib) (requires build)
 - servant-pandoc-0.5.0.0 (lib) (configuration changed)
Downloading  syb-0.7.2.2
Downloaded   syb-0.7.2.2
Starting     syb-0.7.2.2 (lib)
Building     syb-0.7.2.2 (lib)
Installing   syb-0.7.2.2 (lib)
Completed    syb-0.7.2.2 (lib)
Starting     pandoc-types-1.22.2.1 (lib)
Building     pandoc-types-1.22.2.1 (lib)
Installing   pandoc-types-1.22.2.1 (lib)
Completed    pandoc-types-1.22.2.1 (lib)
Configuring library for servant-pandoc-0.5.0.0..
Preprocessing library for servant-pandoc-0.5.0.0..
Building library for servant-pandoc-0.5.0.0..
[1 of 1] Compiling Servant.Docs.Pandoc
```