### PR TITLE
Bump/compiles with ghc 9.4.4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ cabal.sandbox.config
 cabal.project.local
 /*.ebal
 .dir-locals.el
+dist-newstyle/

--- a/cabal.project
+++ b/cabal.project
@@ -1,0 +1,1 @@
+packages: .

--- a/cabal.project
+++ b/cabal.project
@@ -1,1 +1,4 @@
 packages: .
+
+allow-newer:
+  servant-docs:lens

--- a/servant-pandoc.cabal
+++ b/servant-pandoc.cabal
@@ -25,12 +25,12 @@ library
 
   build-depends:       base >=4.7 && <5
                      , http-media >=0.6 && <0.9
-                     , lens >=4.9 && <5
+                     , lens >=4.9 && <6
                      , pandoc-types >=1.22 && <2
-                     , servant-docs >= 0.11.1 && < 0.12
+                     , servant-docs >= 0.11.1 && < 0.13
                      , unordered-containers >=0.2 && <0.3
                      , text >=1.2 && <1.3
-                     , bytestring >=0.10 && <0.11
+                     , bytestring >=0.10 && <0.12
                      , string-conversions >= 0.1 && < 0.5
                      , case-insensitive >= 0.2 && < 1.3
 

--- a/servant-pandoc.cabal
+++ b/servant-pandoc.cabal
@@ -29,7 +29,7 @@ library
                      , pandoc-types >=1.22 && <2
                      , servant-docs >= 0.11.1 && < 0.13
                      , unordered-containers >=0.2 && <0.3
-                     , text >=1.2 && <1.3
+                     , text >=2 && <3
                      , bytestring >=0.10 && <0.12
                      , string-conversions >= 0.1 && < 0.5
                      , case-insensitive >= 0.2 && < 1.3

--- a/servant-pandoc.cabal
+++ b/servant-pandoc.cabal
@@ -29,7 +29,7 @@ library
                      , pandoc-types >=1.22 && <2
                      , servant-docs >= 0.11.1 && < 0.13
                      , unordered-containers >=0.2 && <0.3
-                     , text >=2 && <3
+                     , text (>=1.2 && <1.3) || (>=2 && <3)
                      , bytestring >=0.10 && <0.12
                      , string-conversions >= 0.1 && < 0.5
                      , case-insensitive >= 0.2 && < 1.3

--- a/src/Servant/Docs/Pandoc.hs
+++ b/src/Servant/Docs/Pandoc.hs
@@ -73,10 +73,11 @@ import Servant.Docs (API, Action, DocAuthentication, DocCapture, DocNote,
                      requestExamples, respBody, respStatus, respTypes, response,
                      responseExamples, rqbody, rqtypes)
 
-import           Control.Lens               (mapped, view, (%~), (^.))
+import           Control.Lens               (mapped, view, (%~), (^.), _1)
 import           Data.ByteString.Lazy       (ByteString)
 import qualified Data.ByteString.Lazy.Char8 as B
-import           Data.CaseInsensitive       (foldedCase)
+import qualified Data.ByteString.Char8 as BSC
+import           Data.CaseInsensitive       (foldedCase, original)
 import           Data.Foldable              (fold)
 import qualified Data.HashMap.Strict        as HM
 import           Data.List                  (sort)
@@ -93,6 +94,9 @@ import           Text.Pandoc.Builder    (Blocks, Inlines)
 import qualified Text.Pandoc.Builder    as B
 import           Text.Pandoc.Definition (Pandoc)
 import           Text.Pandoc.JSON       (toJSONFilter)
+import Control.Lens.Combinators (toListOf)
+import Control.Lens (Each(..))
+import Control.Lens (to)
 
 --------------------------------------------------------------------------------
 
@@ -154,7 +158,7 @@ pandocWith renderOpts api = B.doc $ intros <> mconcat endpoints
       , notesStr    (action ^. notes)
       , authStr     (action ^. authInfo)
       , capturesStr (action ^. captures)
-      , headersStr  (action ^. headers)
+      , headersStr  (toListOf (headers . each . _1 . to (T.pack . BSC.unpack . original)) action)
       , paramsStr   (action ^. params)
       , rqbodyStrs  (action ^. rqtypes) (action ^. rqbody)
       , responseStr (action ^. response)


### PR DESCRIPTION
Allows compilation with `ghc-9.4.4`.

The `allow-newer: servant-docs:lens` can be removed from the project when the already applied version bump in `servant-docs` has been [uploaded to hackage](https://github.com/haskell-servant/servant/issues/1636).